### PR TITLE
Fix module import name (lcd -> lcdapi)

### DIFF
--- a/lcd/esp8266_i2c_lcd.py
+++ b/lcd/esp8266_i2c_lcd.py
@@ -1,6 +1,6 @@
 """Implements a character based lcd connected via PCF8574 on I2C."""
 
-from lcd import LcdApi
+from lcdapi import LcdApi
 from machine import I2C
 from time import sleep_ms
 


### PR DESCRIPTION
Updated esp8266_i2c_lcd to use renamed lcdapi class