### PR TITLE
Move the cursor after putting a char

### DIFF
--- a/lcd/lcd_api.py
+++ b/lcd/lcd_api.py
@@ -134,15 +134,15 @@ class LcdApi:
         """Writes the indicated character to the LCD at the current cursor
         position, and advances the cursor by one position.
         """
+        if char != '\n':
+            self.hal_write_data(ord(char))
+            self.cursor_x += 1
         if self.cursor_x >= self.num_columns or char == '\n':
             self.cursor_x = 0
             self.cursor_y += 1
             if self.cursor_y >= self.num_lines:
                 self.cursor_y = 0
             self.move_to(self.cursor_x, self.cursor_y)
-        if char != '\n':
-            self.hal_write_data(ord(char))
-            self.cursor_x += 1
 
     def putstr(self, string):
         """Write the indicated string to the LCD at the current cursor


### PR DESCRIPTION
I moved the `move_to()` after the `hal_write_data()` in `putstr()` so that when you add the last visible character in the 32 character window, the cursor moves back to the home 0,0 position.

Previously, the blinking cursor was moving off screen to 16,1 and jumped to 1,0 on the next `putchar()`.


```
lcd.blink_cursor_on()
lcd.move_to(0,0)
lcd.putstr("12345678901234561234567890123456")
# cursor offscreen (should be 0,0)
lcd.putstr("A")
# cursor at 1,0
```

```
lcd.blink_cursor_on()
lcd.move_to(15,1)
lcd.putstr("Z")
# cursor offscreen (should be 0,0)
lcd.putstr("A")
# cursor at 1,0
```
