### PR TITLE
Fix 16x04 lines 3 and 4

### DIFF
--- a/lcd/lcd_api.py
+++ b/lcd/lcd_api.py
@@ -127,8 +127,10 @@ class LcdApi:
         addr = cursor_x & 0x3f
         if cursor_y & 1:
             addr += 0x40    # Lines 1 & 3 add 0x40
-        if cursor_y & 2:
-            addr += 0x14    # Lines 2 & 3 add 0x14
+        if cursor_y & 2 and self.num_columns == 16:
+            addr += 0x10    # Lines 3 & 4 add 0x10 for 16 cols and 0x14 for 20 cols
+        if cursor_y & 2 and self.num_columns == 20:
+            addr += 0x14
         self.hal_write_command(self.LCD_DDRAM | addr)
 
     def putchar(self, char):


### PR DESCRIPTION
When you using 4 lines with 16 cols, last two lines (3 and 4) are moved by 4 chars. It's because there is hard-coded move by 0x14... But that would work for 20x4 displays. For 16x04 memory map is arranged different way.

source: http://web.alfredstate.edu/faculty/weimandn/lcd/lcd_addressing/lcd_addressing_index.html

This fix is only for 16x04. Regarding to source web pages there could be more logic for other memory maps too (like 40x4 etc...)