### PR TITLE
Working CPython 3 support (tested with 3.8.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Files starting with **nodemcu_** were tested on a
 The files containing **adafruit_lcd** were tested on an Adafruit
 [I2C / SPI character LCD backpack](https://www.adafruit.com/product/292)
 
+## Installing CPython
+
+### Cpython 3.x
+
+    # python smbus needs dev headers
+    sudo apt update
+    sudo apt install python3-dev
+    python -m pip install smbus  # optional, good test before installing library
+    python -m pip install -e .
+
+
+### Cpython 2.7
+
+    # python smbus needs dev headers
+    sudo apt update
+    sudo apt install python2-dev
+    python -m pip install smbus  # optional, good test before installing library
+    python -m pip install -e .
+
+
 ## Tutorial
 
 Giuseppe Cassibba wrote up a [tutorial](https://peppe8o.com/using-i2c-lcd-display-with-raspberry-pi-pico-and-micropython) which demonstrates connecting an I2C LCD to a Raspberry Pi Pico.

--- a/lcd/i2c_lcd.py
+++ b/lcd/i2c_lcd.py
@@ -1,8 +1,10 @@
 """Implements a HD44780 character LCD connected via PCF8574 on I2C."""
 
-from lcd_api import LcdApi
-import smbus
 import time
+
+import smbus
+
+from .lcd_api import LcdApi
 
 # The PCF8574 has a jumper selectable address: 0x20 - 0x27
 DEFAULT_I2C_ADDR = 0x27


### PR DESCRIPTION
Added start of install notes.

Python 3 needs relative paths for import to work.
Updated import order to match pep-8 (system, third party, then custom/local imports).

Demo code that works for me with both CPython 2.7 and 3.8:


    """Display to a HD44780 character LCD connected via PCF8574 on I2C."""

    import sys

    from lcd.i2c_lcd import I2cLcd  # https://github.com/dhylands/python_lcd

    print('Python %r on %r' % (sys.version, sys.platform))

    # The PCF8574 has a jumper selectable address: 0x20 - 0x27
    DEFAULT_I2C_ADDR = 0x27

    lcd = I2cLcd(1, DEFAULT_I2C_ADDR, 2, 16)
    #lcd.blink_cursor_on()
    #lcd.blink_cursor_off()
    lcd.hide_cursor()
    d_str = 'The quick brown fox jumps over t'  #
    lcd.putstr(d_str)
