### PR TITLE
Fix #36

### DIFF
--- a/lcd/i2c_lcd.py
+++ b/lcd/i2c_lcd.py
@@ -60,6 +60,10 @@ class I2cLcd(LcdApi):
         """Allows the hal layer to turn the backlight off."""
         self.bus.write_byte(self.i2c_addr, 0)
 
+    def hal_sleep_us(self, usecs):
+        """Sleep for some time (given in microseconds)."""
+        time.sleep(usecs / 1000000)
+
     def hal_write_command(self, cmd):
         """Writes a command to the LCD.
 

--- a/lcd/lcd_api.py
+++ b/lcd/lcd_api.py
@@ -205,4 +205,4 @@ class LcdApi:
 
     def hal_sleep_us(self, usecs):
         """Sleep for some time (given in microseconds)."""
-        time.sleep_us(usecs)
+        time.sleep_us(usecs)  # NOTE this is not part of Standard Python library, specific hal layers will need to override this


### PR DESCRIPTION
* Implement sub-second sleep function, hal_sleep_us() for i2c (intended for CPython).
* Document with a comment to help with future failures on platforms that are missing `time.sleep_us()`