### PR TITLE
Reset self.implied_newline after pass

### DIFF
--- a/lcd/lcd_api.py
+++ b/lcd/lcd_api.py
@@ -141,7 +141,6 @@ class LcdApi:
                 # self.implied_newline means we advanced due to a wraparound,
                 # so if we get a newline right after that we ignore it.
                 self.implied_newline = False
-                pass
             else:
                 self.cursor_x = self.num_columns
         else:

--- a/lcd/lcd_api.py
+++ b/lcd/lcd_api.py
@@ -140,6 +140,7 @@ class LcdApi:
             if self.implied_newline:
                 # self.implied_newline means we advanced due to a wraparound,
                 # so if we get a newline right after that we ignore it.
+                self.implied_newline = False
                 pass
             else:
                 self.cursor_x = self.num_columns


### PR DESCRIPTION
I noticed that in a loop the newline would sometimes be ignored when it wasn't really an implied newline.  Resetting self.implied_newline to False in the putchar routine before pass fixed the issue. 
